### PR TITLE
Added ability to include signature in a specific message

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "FTLabs GMail Signatures",
   "description": "A Chrome Extension that automagically adds links from RSS feeds to the end of emails sent in the Gmail web client",
-  "version": "1.2.0",
+  "version": "1.2.1",
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -4,6 +4,12 @@
 // polyfill
 require('whatwg-fetch');
 
+function findParentElementByAttribute(el, attr, value){
+
+	while ((el = el.parentElement) && el.getAttribute(attr) !== value);
+	return el;
+}
+
 function getRSSHTML(data){
 
 	return new Promise(function(resolve, reject){
@@ -45,7 +51,11 @@ function populateSignatures(data, force) {
 
 	messageBodies
 	.forEach(function (message) {
-
+		var parent = findParentElementByAttribute(message, 'role', 'dialog');
+		console.log(parent);
+		if(parent === null){
+			throw Error("Message is in a reply thread");
+		}
 		// mark that this has a signature set
 		message.dataset.ftsig = '1';
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -9,16 +9,9 @@ function findParentElementByAttribute(el, attr, value){
 	return el;
 }
 
-function findParentElementByTag(el, tag){
-	while ( (el = el.parentElement) && el.nodeName.toLowerCase() !== tag) ;
-	return el;
-}
-
 function getRSSHTML(data){
 
 	return new Promise(function(resolve, reject){
-
-			console.log(data);
 
 			if (data) {
 			
@@ -56,7 +49,6 @@ function populateSignatures(data, force) {
 	messageBodies
 	.forEach(function (message) {
 		const parent = findParentElementByAttribute(message, 'role', 'dialog');
-		// console.log(parent);
 
 		// If we're in a compose window, our message dialog has a parent with role="dialog" on the element
 		// The response dialogs in GMail do not have this parent with this attribute
@@ -65,10 +57,8 @@ function populateSignatures(data, force) {
 		// the may be dialogs and treat them appropriately
 
 		if(parent === null){
-			console.log(message);
 			const containingElement = findParentElementByAttribute(message, 'class', 'iN');
 			const addAnywayApendee = containingElement.querySelector('.gU.OoRYyc:not([data-sig-pone-assigned="true"])');
-			console.log(addAnywayApendee);
 
 			if(addAnywayApendee === null){
 				return false;
@@ -78,6 +68,8 @@ function populateSignatures(data, force) {
 			pOne.textContent = 'Add RSS signature';
 			pOne.setAttribute('style', 'font-size: 0.5em; cursor: pointer; float: left; position: absolute; top: 0; height: 100%; display: flex; align-items: center;');
 			pOne.addEventListener('click', function(){
+				this.style.opacity = 0.4;
+				this.textContent = 'Getting signature...';
 
 				getPopupInfo()
 					.then(data => getRSSHTML(data))
@@ -89,6 +81,9 @@ function populateSignatures(data, force) {
 						}
 						const sig = document.createRange().createContextualFragment(body);
 						containingElement.querySelector('.editable[aria-label="Message Body"]').appendChild(sig);
+
+						this.style.opacity = 1;
+						this.textContent = 'Add RSS signature';
 
 					})
 				;


### PR DESCRIPTION
For a reply thread, a signature will never be automagically added. The user must click the 'Add RSS signature' add the bottom of the compose message dialog to include one. A signature will then be added only to that reply based on the preferences set in the ext.
