### PR TITLE
Changed descripitions/names (but not values) of selectable items

### DIFF
--- a/src/dialog.html
+++ b/src/dialog.html
@@ -135,7 +135,7 @@
 
 						<td>
 							<input class="o-forms-checkbox" type="checkbox" id="include-description" value="true" checked></input>
-							<label class="o-forms-label" for="include-description">Description</label>
+							<label class="o-forms-label" for="include-description">Teaser</label>
 						</td>
 					</tr>
 
@@ -148,7 +148,7 @@
 				<select class="o-forms-select" id="size" data-clickable="true">
 					<option value="small">Small</option>
 					<option value="medium">Medium</option>
-					<option value="full" selected>Full</option>
+					<option value="full" selected>Large</option>
 				</select>
 			</div>
 			


### PR DESCRIPTION
Decided to change only the labels of the items we're storing/sending to the server. This keeps the interface with the web service the same and saves us having to write logic to update the values saved in existing installations.
