### PR TITLE
Isolating weird behaviour

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,9 +15,6 @@
       "js": ["scripts/main.js"]
     }
   ],
-  "permissions": [
-    "tabs"
-  ],
   "background": {
     "scripts": ["scripts/background.js"],
     "persistent": true

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,9 @@
       "js": ["scripts/main.js"]
     }
   ],
+  "permissions": [
+    "tabs"
+  ],
   "background": {
     "scripts": ["scripts/background.js"],
     "persistent": true

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -87,7 +87,7 @@ function populateSignatures(data, force) {
 					const signature = document.createElement('div');
 					signature.setAttribute('href', 'http://ftsig');
 					signature.innerHTML = body;
-					sigTarget.appendChild(signature);
+					sigTarget.insertBefore(signature, sigTarget.querySelector('.gmail_extra'));
 
 					this.style.opacity = 1;
 					this.textContent = 'Refresh RSS signature';
@@ -141,10 +141,10 @@ function populateSignatures(data, force) {
 		.then(body => {
 			if (topLevelSig) {
 				message.insertBefore(signature, topLevelSig);
+			} else {
+				message.insertBefore(signature, message.querySelector('.gmail_extra'));
 			}
-			signature.appendChild(
-				document.createRange().createContextualFragment(body)
-			);
+			signature.innerHTML = body;
 			spinner.removeSpinner();
 		})
 		.catch(e => {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -59,14 +59,14 @@ function populateSignatures(data, force) {
 		if (parent === null) {
 			const containingElement = findParentElementByAttribute(message, 'class', 'iN');
 			if (!containingElement) {
-				return;
+				return false;
 			}
 
 			const sigTarget = containingElement.querySelector('.editable[aria-label="Message Body"]');
 			const addAnywayApendee = containingElement.querySelector('.gU.OoRYyc:not([data-sig-pone-assigned="true"])');
 
 			if (addAnywayApendee === null || sigTarget === null) {
-				return;
+				return false;
 			}
 
 			const pOne = document.createElement('span');


### PR DESCRIPTION
This is a bit of a complex one.

It changes the behaviour of the extension a little. Both the email reply signature button and the email reply window opening should behave the same.
- If there is an existing top level signature it replaces it.
- It removes any old extensions (including in old messages if the old message thread has been uncollapsed)
- It uses the <div href='http://ftsig'> to identify existing signatures in both situations now since the class gets removed by google.
- It tries to place it before the old mesage thread identified by '.gmail_extra' but failing that it just sticks it at the bottom.

I've tested it. It seems to work well now and should be much more robust. Hopefully that fixes the issue of the signatures being added to all replies as it removes all signatures not just first level ones.
