### PR TITLE
Added o-tracking to gmail signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,9 @@
   "author": "FTLabs",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.6.4",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babelify": "^7.2.0",
     "bower": "^1.7.7",
     "browserify": "^12.0.1",
     "gulp": "^3.9.1",
-    "gulp-babel": "^6.1.2",
     "nodemon": "^1.8.1",
     "origami-build-tools": "^5.0.0",
     "whatwg-fetch": "^0.10.1"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "FTLabs GMail Signatures",
   "description": "A Chrome Extension that automagically adds links from RSS feeds to the end of emails sent in the Gmail web client",
-  "version": "1.4.1",
+  "version": "1.5.0",
 
   "browser_action": {
     "default_icon": "icon.png",

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -56,10 +56,24 @@ function populateSignatures(data, force) {
 	.forEach(function (message) {
 		const parent = findParentElementByAttribute(message, 'role', 'dialog');
 		
-		const submitButton = parent.querySelector("[id=':kq']");
+		const submitButton = parent.querySelector(".gU.Up");
 		
 		submitButton.addEventListener('click', function(){
-			new CustomEvent('oTracking.event', { detail: { category: 'email with FT Labs Gmail Signature', action: 'sent' }, bubbles: true})
+			
+			// Circumstances exist where a user can click send, and the email doesn't send
+			//  - such as forgetting to put a recipient in the dialog. So, when the send
+			// button is clicked, we wait 3 seconds, and see if there's a success dialog i
+			// somewhere in the page.
+			 			
+			setTimeout(function(){
+				const successDialog = document.querySelector("[role='alert'] .vh span[param]");
+				if (successDialog !== null){
+					// The email was sent, registering with o-tracking
+					new CustomEvent('oTracking.event', { detail: { category: 'email with FT Labs Gmail Signature', action: 'sent' }, bubbles: true});
+				}
+							
+			}, 3000);
+			
 		}, false);
 
 		// If we're in a compose window, our message dialog has a parent with role="dialog" on the element

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -3,7 +3,12 @@
 
 // polyfill
 require('whatwg-fetch');
-var oTracking = require('o-tracking');
+var oTracking = require('o-tracking').init({
+	server: 'https://spoor-api.ft.com/px.gif',
+	context: {
+		product: 'FTLabs Gmail Signatures'
+	}
+});
 
 function findParentElementByAttribute(el, attr, value){
 	while ((el = el.parentElement) && el.getAttribute(attr) !== value);
@@ -50,6 +55,12 @@ function populateSignatures(data, force) {
 	messageBodies
 	.forEach(function (message) {
 		const parent = findParentElementByAttribute(message, 'role', 'dialog');
+		
+		const submitButton = parent.querySelector("[id=':kq']");
+		
+		submitButton.addEventListener('click', function(){
+			new CustomEvent('oTracking.event', { detail: { category: 'email with FT Labs Gmail Signature', action: 'sent' }, bubbles: true})
+		}, false);
 
 		// If we're in a compose window, our message dialog has a parent with role="dialog" on the element
 		// The response dialogs in GMail do not have this parent with this attribute
@@ -60,7 +71,7 @@ function populateSignatures(data, force) {
 		if(parent === null){
 			const containingElement = findParentElementByAttribute(message, 'class', 'iN');
 			const addAnywayApendee = containingElement.querySelector('.gU.OoRYyc:not([data-sig-pone-assigned="true"])');
-
+			
 			if(addAnywayApendee === null){
 				return false;
 			}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -84,7 +84,6 @@ function populateSignatures(data, force) {
 		if(parent === null){
 			const containingElement = findParentElementByAttribute(message, 'class', 'iN');
 			const addAnywayApendee = containingElement.querySelector('.gU.OoRYyc:not([data-sig-pone-assigned="true"])');
-			
 			if(addAnywayApendee === null){
 				return false;
 			}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -69,9 +69,8 @@ function populateSignatures(data, force) {
 				const successDialog = document.querySelector("[role='alert'] .vh span[param]");
 				if (successDialog !== null){
 					// The email was sent, registering with o-tracking
-					new CustomEvent('oTracking.event', { detail: { category: 'email with FT Labs Gmail Signature', action: 'sent' }, bubbles: true});
-				}
-							
+					oTracking.event({ detail: { category: 'A usr can send an email with an FT Labs Gmail Signature', action: 'sent' }, bubbles: true} );
+				}		
 			}, 3000);
 			
 		}, false);


### PR DESCRIPTION
We can track the person clicking the send button, but not hitting cmd + return to send. GMail's crazy element naming/AJAXy nature makes it really difficult to hook into the action of sending an email, with this PR we infer that an email has been sent by listening for a click on the send button, and checking for a success notification 3 seconds later.
